### PR TITLE
Ignore dependencies (sub-charts) early

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/mkmik/multierror"
+	"helm.sh/helm/v3/pkg/chart"
 	helmRepo "helm.sh/helm/v3/pkg/repo"
 	"k8s.io/klog"
 
@@ -459,6 +460,18 @@ func ShouldIgnoreRepo(repo api.Repo, syncTrusted, ignoreTrusted []*api.Repo) boo
 
 	for _, ignoreTrRepo := range ignoreTrusted {
 		if GetRepoLocationId(GetRepoLocation(ignoreTrRepo)) == repoLocationId {
+			return true
+		}
+	}
+
+	return false
+}
+
+func ShouldIgnoreDependency(dependency *chart.Dependency, ignoreTrusted []*api.Repo) bool {
+	dependencyRepoUrl := strings.TrimSuffix(dependency.Repository, "/")
+	for _, ignoreTrRepo := range ignoreTrusted {
+		trustedRepoUrl := strings.TrimSuffix(ignoreTrRepo.GetUrl(), "/")
+		if trustedRepoUrl == dependencyRepoUrl {
 			return true
 		}
 	}

--- a/pkg/syncer/index.go
+++ b/pkg/syncer/index.go
@@ -2,9 +2,10 @@ package syncer
 
 import (
 	"fmt"
-	"github.com/bitnami-labs/charts-syncer/api"
 	"sort"
 	"time"
+
+	"github.com/bitnami-labs/charts-syncer/api"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/juju/errors"
@@ -235,6 +236,12 @@ func (s *Syncer) loadChart(name string, version string, repository string, isDep
 
 		var errs error
 		for _, dep := range deps {
+			if utils.ShouldIgnoreDependency(dep, s.source.IgnoreTrustedRepos) {
+				klog.V(4).Infof("Ignoring dependency %q because it is listed in ignoreTrustedRepos as URL %q",
+					dep.Name, dep.Repository)
+				continue
+			}
+
 			depID := fmt.Sprintf("%s-%s", dep.Name, dep.Version)
 			if err := s.loadChart(dep.Name, dep.Version, dep.Repository, true); err != nil {
 				errs = multierror.Append(errs, errors.Annotatef(err, "invalid %q chart dependency", depID))


### PR DESCRIPTION
If a sub-chart is listed in ignoreTrustedRepos, do not try to fetch it